### PR TITLE
Potential fix for code scanning alert no. 8: User-controlled bypass of sensitive method

### DIFF
--- a/API/Controllers/UserController.cs
+++ b/API/Controllers/UserController.cs
@@ -78,12 +78,18 @@ public class UserController(
     [HttpGet]
     public async Task<IActionResult> GetUser([FromQuery] string? usernameOrEmail)
     {
-        if (usernameOrEmail == null)
+        ClaimsPrincipal user = HttpContext.User;
+
+        if (user?.Identity == null || !user.Identity.IsAuthenticated)
         {
-            ClaimsPrincipal user = HttpContext.User;
-            return user.Identity != null && !user.Identity.IsAuthenticated ? Unauthorized() : Ok(await userService.GetUser(user.Identity.Name));
+            return Unauthorized();
         }
-        User result = await userService.GetUser(usernameOrEmail);
+
+        var lookupKey = string.IsNullOrWhiteSpace(usernameOrEmail)
+            ? user.Identity.Name
+            : usernameOrEmail;
+
+        User result = await userService.GetUser(lookupKey);
         return Ok(result);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Kruzk02/grocery-store-api/security/code-scanning/8](https://github.com/Kruzk02/grocery-store-api/security/code-scanning/8)

In general, the fix is to ensure that authentication/authorization decisions are not controlled by user input. The decision whether to return `Unauthorized()` should be based only on server-side authentication state (the `HttpContext.User` principal) and any trusted data, not on the presence or absence of a query parameter. If the endpoint is intended to allow access to the current user’s own data when `usernameOrEmail` is omitted, and perhaps admin-only access by username/email when provided, that must be enforced explicitly using roles or other server-side checks.

The best minimal fix here is to remove the implicit bypass created by the `if (usernameOrEmail == null)` branch and always base access on the authenticated principal. A straightforward approach that does not change other functionality is:
- Always require an authenticated user (`user.Identity?.IsAuthenticated == true`) and return `Unauthorized()` otherwise, regardless of query parameters.
- Decide which username to look up using a trusted source: either the current principal name if `usernameOrEmail` is null or empty, or the query parameter if non-empty.
- If querying by arbitrary `usernameOrEmail` should be restricted (e.g., to admins), enforce that with role checks, not with the nullable query parameter.

Because we must avoid guessing complex new behavior, the smallest secure change is to (a) perform an early authentication check independent of `usernameOrEmail`, and (b) simplify the logic so that the `Unauthorized()` path is not controlled by the query parameter. For example:
```csharp
[Authorize]
[HttpGet]
public async Task<IActionResult> GetUser([FromQuery] string? usernameOrEmail)
{
    ClaimsPrincipal user = HttpContext.User;
    if (user?.Identity == null || !user.Identity.IsAuthenticated)
    {
        return Unauthorized();
    }

    var lookupKey = string.IsNullOrWhiteSpace(usernameOrEmail)
        ? user.Identity.Name
        : usernameOrEmail;

    User result = await userService.GetUser(lookupKey);
    return Ok(result);
}
```
This maintains the existing capability (query by `usernameOrEmail` if provided; otherwise default to current user), but makes the `Unauthorized()` decision entirely dependent on the principal, not on query input. All needed types (`ClaimsPrincipal`, `User`) and imports are already present in the snippet, so no new imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
